### PR TITLE
Update index.qmd

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Learn GRASS GIS <span style='font-size: 0.8em; color: gray;'>(An Open-Source GIS)</span>"
+title: "Learn GRASS GIS "
 listing:
     contents: 
         - content/tutorials
@@ -8,5 +8,7 @@ listing:
     categories: true
     filter-ui: [title, categories]
 page-layout: full
+description: |
+  Hands-on tutorials for learning [GRASS GIS](https://grass.osgeo.org), the open-source geospatial processing engine.
 title-block-banner: false
 ---


### PR DESCRIPTION
This PR updates the homepage text in index.qmd to improve clarity and provide a more informative description of GRASS GIS. The new description briefly explains the purpose of the tutorials and includes a direct link to the official GRASS GIS website.

Change:

Added a description field to index.qmd

Let me know if you’d like any refinements! 